### PR TITLE
add kubernetes-networks hw

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -13,6 +13,14 @@ spec:
   containers:
   - name: web
     image: azx9095/test-nginx:latest
+    readinessProbe:
+      httpGet:
+        path: /index.html
+        port: 80
+    livenessProbe:
+      tcpSocket:
+        port: 8000
+
     volumeMounts:
     - name: app
       mountPath: /app

--- a/kubernetes-networks/canary/01-prod-svc.yaml
+++ b/kubernetes-networks/canary/01-prod-svc.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prod-svc
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: prod-svc
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: prod-svc
+      labels:
+        app: prod-svc
+    spec:
+      containers:
+      - name: hello-kubernetes
+        image: paulbouwer/hello-kubernetes:1.8
+        ports:
+        - containerPort: 8080
+        env:
+        - name: MESSAGE
+          value: Prod service
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: prod-svc
+spec:
+  clusterIP: None
+  selector:
+    app: prod-svc
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/kubernetes-networks/canary/02-canary-svc.yaml
+++ b/kubernetes-networks/canary/02-canary-svc.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary-svc
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: canary-svc
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  template:
+    metadata:
+      name: canary-svc
+      labels:
+        app: canary-svc
+    spec:
+      containers:
+      - name: hello-kubernetes
+        image: paulbouwer/hello-kubernetes:1.8
+        ports:
+        - containerPort: 8080
+        env:
+        - name: MESSAGE
+          value: Canary service
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: canary-svc
+spec:
+  clusterIP: None
+  selector:
+    app: canary-svc
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/kubernetes-networks/canary/03-prod-svc-ingress.yaml
+++ b/kubernetes-networks/canary/03-prod-svc-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: prod-service-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /service
+        backend:
+          serviceName: prod-svc
+          servicePort: 8080

--- a/kubernetes-networks/canary/04-canary-svc-ingress.yaml
+++ b/kubernetes-networks/canary/04-canary-svc-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: canary-service-ingress
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "X-Canary-Header"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /service
+        backend:
+          serviceName: canary-svc
+          servicePort: 8080

--- a/kubernetes-networks/coredns/coredns-lb-tcp.yaml
+++ b/kubernetes-networks/coredns/coredns-lb-tcp.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-lb-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+  - protocol: TCP
+    port: 53
+    targetPort: 53

--- a/kubernetes-networks/coredns/coredns-lb-udp.yaml
+++ b/kubernetes-networks/coredns/coredns-lb-udp.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-lb-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.10
+  ports:
+  - protocol: UDP
+    port: 53
+    targetPort: 53

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kubernetes-dashboard-ingress
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        backend:
+          serviceName: kubernetes-dashboard
+          servicePort: 8443

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,18 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+
+    spec:
+      volumes:
+      - name: app
+        emptyDir: {}
+
+      containers:
+      - name: web
+        image: azx9095/test-nginx:latest
+        ports:
+        - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+
+        volumeMounts:
+        - name: app
+          mountPath: /app
+
+      initContainers:
+      - name: init
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  clusterIP: None
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [X] Основное ДЗ
 - [X] Задание со *

## В процессе сделано:
 - Добавил проверки readinessProbe и livenessProbe для пода.
 - "Почему следующая конфигурация(проверка наличия процесса) валидна, но не имеет смысла?"
    Обычно в docker-контейнере запускают один процесс. Соответственно, если
  этот процесс упадет, то упадет и сам контейнер. 
   "Бывают ли ситуации, когда она все-таки имеет смысл?"
    Смысл имеется, если в контейнере несколько процессов и наличие вспомогательных процессов
  влияют на работу основного.
 - На основе существующего пода сделал deployment.
 - Создал СlusterIP сервис.
 - Настроил ipvs в minikube.
 - Установил metallb.
 - Сделал доступным coredns вне кластера через аннотации для metallb.
 - Установил nginx ingress.
 - Установил и сделал доступным вне кластера kubernetes dashboard.
 - Так и не разобрался с canary-аннотациями для nginx ingress. Создаю 2 сервиса - prod и canary. Также создаю 2 ingress. У canary-ingress добавляю canary-аннатоции. После добавления в кластер весь трафик идет на prod сервис. Использовал разные canary-аннотации, но результат тот же.

## PR checklist:
 - [X] Выставлен label с темой домашнего задания
